### PR TITLE
[MSHARED-1098] Drop legacy stuff, make project Java8 and modern stuff

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,12 +79,15 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-digest</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -87,22 +87,15 @@
       <version>${mavenVersion}</version>
       <scope>provided</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-digest</artifactId>
-      <version>1.1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-component-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
       <version>3.4.2</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.15</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.maven.shared</groupId>
     <artifactId>maven-shared-components</artifactId>
-    <version>34</version>
+    <version>36</version>
     <relativePath />
   </parent>
 
@@ -58,22 +58,23 @@
   </distributionManagement>
 
   <properties>
-    <mavenVersion>3.1.0</mavenVersion>
-    <javaVersion>7</javaVersion>
+    <javaVersion>8</javaVersion>
+    <mavenVersion>3.2.5</mavenVersion>
+    <slf4jVersion>1.7.36</slf4jVersion>
     <project.build.outputTimestamp>2020-04-04T09:03:59Z</project.build.outputTimestamp>
   </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-component-annotations</artifactId>
-        <version>2.1.0</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4jVersion}</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
@@ -83,17 +84,6 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
       <version>${mavenVersion}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.shared</groupId>
-      <artifactId>maven-shared-utils</artifactId>
-      <version>3.3.3</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-container-default</artifactId>
-      <version>2.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
@@ -109,30 +99,42 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.3.0</version>
+      <version>3.4.2</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.bcel</groupId>
       <artifactId>bcel</artifactId>
-      <version>6.2</version><!-- Java 7 -->
+      <version>6.5.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
-      <version>4.2</version><!-- Java 7 -->
-    </dependency>
-
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-component-annotations</artifactId>
+      <version>4.3</version>
     </dependency>
 
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4jVersion}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.plexus</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <version>5.1.0</version>
       <scope>test</scope>
     </dependency>
 
@@ -141,16 +143,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-component-metadata</artifactId>
-        <version>2.1.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>generate-metadata</goal>
-            </goals>
-          </execution>
-        </executions>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>sisu-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/org/apache/maven/shared/jar/JarAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/jar/JarAnalyzer.java
@@ -31,6 +31,7 @@ import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 
 /**
@@ -115,13 +116,7 @@ public class JarAnalyzer
         List<JarEntry> entries = Collections.list( jarFile.entries() );
 
         // Sorting of list is done by name to ensure a bytecode hash is always consistent.
-        Collections.sort( entries, new Comparator<JarEntry>()
-        {
-            public int compare( JarEntry entry1, JarEntry entry2 )
-            {
-                return entry1.getName().compareTo( entry2.getName() );
-            }
-        } );
+        entries.sort( Comparator.comparing( ZipEntry::getName ) );
 
         Manifest manifest;
         try

--- a/src/main/java/org/apache/maven/shared/jar/JarData.java
+++ b/src/main/java/org/apache/maven/shared/jar/JarData.java
@@ -21,7 +21,7 @@ package org.apache.maven.shared.jar;
 
 import org.apache.maven.shared.jar.classes.JarClasses;
 import org.apache.maven.shared.jar.identification.JarIdentification;
-import org.apache.maven.shared.utils.StringUtils;
+import org.codehaus.plexus.util.StringUtils;
 
 import java.io.File;
 import java.util.Collections;

--- a/src/main/java/org/apache/maven/shared/jar/classes/ImportVisitor.java
+++ b/src/main/java/org/apache/maven/shared/jar/classes/ImportVisitor.java
@@ -39,12 +39,12 @@ public class ImportVisitor
     /**
      * The list of imports discovered.
      */
-    private List<String> imports;
+    private final List<String> imports;
 
     /**
      * The Java class that is being analyzed.
      */
-    private JavaClass javaClass;
+    private final JavaClass javaClass;
 
     /**
      * Pattern to detect if the import is qualified and allows retrieval of the actual import name from the string via
@@ -68,7 +68,7 @@ public class ImportVisitor
 
         // Create a list that is guaranteed to be unique while retaining it's list qualities (LinkedHashSet does not
         // expose the list interface even if natural ordering is retained)  
-        this.imports = SetUniqueList.setUniqueList( new ArrayList<String>() );
+        this.imports = SetUniqueList.setUniqueList( new ArrayList<>() );
     }
 
     /**
@@ -86,6 +86,7 @@ public class ImportVisitor
      *
      * @see org.apache.bcel.classfile.EmptyVisitor#visitConstantClass(org.apache.bcel.classfile.ConstantClass)
      */
+    @Override
     public void visitConstantClass( ConstantClass constantClass )
     {
         String name = constantClass.getBytes( javaClass.getConstantPool() );
@@ -119,6 +120,7 @@ public class ImportVisitor
      *
      * @see org.apache.bcel.classfile.EmptyVisitor#visitConstantUtf8(org.apache.bcel.classfile.ConstantUtf8)
      */
+    @Override
     public void visitConstantUtf8( ConstantUtf8 constantUtf8 )
     {
         String ret = constantUtf8.getBytes().trim();

--- a/src/main/java/org/apache/maven/shared/jar/classes/JarClasses.java
+++ b/src/main/java/org/apache/maven/shared/jar/classes/JarClasses.java
@@ -35,22 +35,22 @@ public class JarClasses
     /**
      * The list of imports in the classes in the JAR.
      */
-    private List<String> imports;
+    private final List<String> imports;
 
     /**
      * A list of packages represented by classes in the JAR.
      */
-    private List<String> packages;
+    private final List<String> packages;
 
     /**
      * A list of the classes that in the JAR.
      */
-    private List<String> classNames;
+    private final List<String> classNames;
 
     /**
      * A list of methods within the classes in the JAR.
      */
-    private List<String> methods;
+    private final List<String> methods;
 
     /**
      * Whether the JAR contains any code with debug information. If there is a mix of debug and release code, this will
@@ -71,10 +71,10 @@ public class JarClasses
     {
         // Unique list decorators are used to ensure natural ordering is retained, the list interface is availble, and
         // that duplicates are not entered.
-        imports = SetUniqueList.setUniqueList( new ArrayList<String>() );
-        packages = SetUniqueList.setUniqueList( new ArrayList<String>() );
-        classNames = SetUniqueList.setUniqueList( new ArrayList<String>() );
-        methods = SetUniqueList.setUniqueList( new ArrayList<String>() );
+        imports = SetUniqueList.setUniqueList( new ArrayList<>() );
+        packages = SetUniqueList.setUniqueList( new ArrayList<>() );
+        classNames = SetUniqueList.setUniqueList( new ArrayList<>() );
+        methods = SetUniqueList.setUniqueList( new ArrayList<>() );
     }
 
     /**

--- a/src/main/java/org/apache/maven/shared/jar/classes/JarClassesAnalysis.java
+++ b/src/main/java/org/apache/maven/shared/jar/classes/JarClassesAnalysis.java
@@ -19,6 +19,9 @@ package org.apache.maven.shared.jar.classes;
  * under the License.
  */
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.bcel.classfile.ClassFormatException;
 import org.apache.bcel.classfile.ClassParser;
 import org.apache.bcel.classfile.DescendingVisitor;
@@ -26,8 +29,8 @@ import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.LineNumberTable;
 import org.apache.bcel.classfile.Method;
 import org.apache.maven.shared.jar.JarAnalyzer;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
@@ -41,10 +44,12 @@ import java.util.jar.JarEntry;
  *
  * @see #analyze(org.apache.maven.shared.jar.JarAnalyzer)
  */
-@Component ( role = JarClassesAnalysis.class )
+@Singleton
+@Named
 public class JarClassesAnalysis
-    extends AbstractLogEnabled
 {
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
     private static final double JAVA_1_8_CLASS_VERSION = 52.0;
 
     private static final double JAVA_1_7_CLASS_VERSION = 51.0;
@@ -133,12 +138,12 @@ public class JarClassesAnalysis
                 }
                 catch ( ClassFormatException e )
                 {
-                    getLogger().warn( "Unable to process class " + classname + " in JarAnalyzer File " + jarfilename,
+                    logger.warn( "Unable to process class " + classname + " in JarAnalyzer File " + jarfilename,
                                       e );
                 }
                 catch ( IOException e )
                 {
-                    getLogger().warn( "Unable to process JarAnalyzer File " + jarfilename, e );
+                    logger.warn( "Unable to process JarAnalyzer File " + jarfilename, e );
                 }
             }
 

--- a/src/main/java/org/apache/maven/shared/jar/identification/JarIdentification.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/JarIdentification.java
@@ -57,27 +57,27 @@ public class JarIdentification
     /**
      * The list of possible group IDs discovered.
      */
-    private List<String> potentialGroupIds = new ArrayList<>();
+    private final List<String> potentialGroupIds = new ArrayList<>();
 
     /**
      * The list of possible artifact IDs discovered.
      */
-    private List<String> potentialArtifactIds = new ArrayList<>();
+    private final List<String> potentialArtifactIds = new ArrayList<>();
 
     /**
      * The list of possible versions discovered.
      */
-    private List<String> potentialVersions = new ArrayList<>();
+    private final List<String> potentialVersions = new ArrayList<>();
 
     /**
      * The list of possible artifact names discovered.
      */
-    private List<String> potentialNames = new ArrayList<>();
+    private final List<String> potentialNames = new ArrayList<>();
 
     /**
      * The list of possible vendors discovered.
      */
-    private List<String> potentialVendors = new ArrayList<>();
+    private final List<String> potentialVendors = new ArrayList<>();
 
     /**
      * Add a validated group ID.

--- a/src/main/java/org/apache/maven/shared/jar/identification/JarIdentificationAnalysis.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/JarIdentificationAnalysis.java
@@ -19,13 +19,16 @@ package org.apache.maven.shared.jar.identification;
  * under the License.
  */
 
-import org.apache.maven.shared.jar.JarAnalyzer;
-import org.apache.maven.shared.utils.StringUtils;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
 
-import java.util.Collections;
+import org.apache.maven.shared.jar.JarAnalyzer;
+import org.codehaus.plexus.util.StringUtils;
+
 import java.util.List;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Analyze the JAR file to identify Maven artifact metadata. This class is thread safe and immutable as long as all
@@ -33,20 +36,23 @@ import java.util.List;
  * <p/>
  * If using Plexus, the class will use all available exposers in the container.
  * <p/>
- * If not using Plexus, the exposers must be set using {@link #setExposers(java.util.List)} before calling
- * {@link #analyze(org.apache.maven.shared.jar.JarAnalyzer)}
- * <p/>
  * Note that you must first create an instance of {@link org.apache.maven.shared.jar.JarAnalyzer} - see its Javadoc for
  * a typical use.
  */
-@Component( role =  JarIdentificationAnalysis.class )
+@Singleton
+@Named
 public class JarIdentificationAnalysis
 {
     /**
      * The Maven information exposers to use during identification.
      */
-    @Requirement( role = JarIdentificationExposer.class )
-    private List<JarIdentificationExposer> exposers;
+    private final List<JarIdentificationExposer> exposers;
+
+    @Inject
+    public JarIdentificationAnalysis( List<JarIdentificationExposer> exposers )
+    {
+        this.exposers = requireNonNull( exposers );
+    }
 
     /**
      * Analyze a JAR and find any associated Maven metadata. Note that if the provided JAR analyzer has previously
@@ -142,10 +148,5 @@ public class JarIdentificationAnalysis
             }
         }
         return largest;
-    }
-
-    public void setExposers( List<JarIdentificationExposer> exposers )
-    {
-        this.exposers = Collections.unmodifiableList( exposers );
     }
 }

--- a/src/main/java/org/apache/maven/shared/jar/identification/exposers/EmbeddedMavenModelExposer.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/exposers/EmbeddedMavenModelExposer.java
@@ -19,15 +19,18 @@ package org.apache.maven.shared.jar.identification.exposers;
  * under the License.
  */
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Organization;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.shared.jar.JarAnalyzer;
 import org.apache.maven.shared.jar.identification.JarIdentification;
 import org.apache.maven.shared.jar.identification.JarIdentificationExposer;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,11 +41,14 @@ import java.util.jar.JarEntry;
 /**
  * Exposer that examines a JAR file for any embedded Maven metadata for identification.
  */
-@Component( role = JarIdentificationExposer.class, hint = "embeddedMavenModel" )
+@Singleton
+@Named( "embeddedMavenModel" )
 public class EmbeddedMavenModelExposer
-    extends AbstractLogEnabled
     implements JarIdentificationExposer
 {
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Override
     public void expose( JarIdentification identification, JarAnalyzer jarAnalyzer )
     {
         List<JarEntry> entries = jarAnalyzer.getMavenPomEntries();
@@ -53,7 +59,7 @@ public class EmbeddedMavenModelExposer
 
         if ( entries.size() > 1 )
         {
-            getLogger().warn(
+            logger.warn(
                 "More than one Maven model entry was found in the JAR, using only the first of: " + entries );
         }
 
@@ -96,11 +102,11 @@ public class EmbeddedMavenModelExposer
         }
         catch ( IOException e )
         {
-            getLogger().error( "Unable to read model " + pom.getName() + " in " + jarAnalyzer.getFile() + ".", e );
+            logger.error( "Unable to read model " + pom.getName() + " in " + jarAnalyzer.getFile() + ".", e );
         }
         catch ( XmlPullParserException e )
         {
-            getLogger().error( "Unable to parse model " + pom.getName() + " in " + jarAnalyzer.getFile() + ".", e );
+            logger.error( "Unable to parse model " + pom.getName() + " in " + jarAnalyzer.getFile() + ".", e );
         }
     }
 }

--- a/src/main/java/org/apache/maven/shared/jar/identification/exposers/FilenameExposer.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/exposers/FilenameExposer.java
@@ -19,11 +19,13 @@ package org.apache.maven.shared.jar.identification.exposers;
  * under the License.
  */
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.maven.shared.jar.JarAnalyzer;
 import org.apache.maven.shared.jar.identification.JarIdentification;
 import org.apache.maven.shared.jar.identification.JarIdentificationExposer;
-import org.apache.maven.shared.utils.io.FileUtils;
-import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.util.FileUtils;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -33,12 +35,14 @@ import java.util.regex.Pattern;
  * Exposer that examines a JAR file to derive Maven metadata from the pattern of the JAR's filename.
  * Will match the format <i>artifactId</i>-<i>version</i>.jar.
  */
-@Component( role = JarIdentificationExposer.class, hint = "filename" )
+@Singleton
+@Named( "filename" )
 public class FilenameExposer
     implements JarIdentificationExposer
 {
-    private static final Pattern VERSION_PATTERN = Pattern.compile( "-[0-9]" );
+    private static final Pattern VERSION_PATTERN = Pattern.compile( "-\\d" );
 
+    @Override
     public void expose( JarIdentification identification, JarAnalyzer jarAnalyzer )
     {
         String filename = FileUtils.removeExtension( jarAnalyzer.getFile().getName() );

--- a/src/main/java/org/apache/maven/shared/jar/identification/exposers/JarClassesExposer.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/exposers/JarClassesExposer.java
@@ -19,28 +19,36 @@ package org.apache.maven.shared.jar.identification.exposers;
  * under the License.
  */
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.maven.shared.jar.JarAnalyzer;
 import org.apache.maven.shared.jar.classes.JarClasses;
 import org.apache.maven.shared.jar.classes.JarClassesAnalysis;
 import org.apache.maven.shared.jar.identification.JarIdentification;
 import org.apache.maven.shared.jar.identification.JarIdentificationExposer;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Exposer that examines a JAR file to derive Maven metadata from the classes in a JAR. It will currently identify
  * potential group IDs from the class packages.
- * <p/>
- * Note: if not being used from Plexus, the {@link #setAnalyzer(org.apache.maven.shared.jar.classes.JarClassesAnalysis)}
- * method must be called to avoid a NullPointerException during the expose method.
  */
-@Component( role = JarIdentificationExposer.class, hint = "jarClasses" )
+@Singleton
+@Named( "jarClasses" )
 public class JarClassesExposer
     implements JarIdentificationExposer
 {
-    @Requirement
-    private JarClassesAnalysis analyzer;
+    private final JarClassesAnalysis analyzer;
 
+    @Inject
+    public JarClassesExposer( JarClassesAnalysis analyzer )
+    {
+        this.analyzer = requireNonNull( analyzer );
+    }
+
+    @Override
     public void expose( JarIdentification identification, JarAnalyzer jarAnalyzer )
     {
         JarClasses jarclasses = analyzer.analyze( jarAnalyzer );
@@ -49,10 +57,5 @@ public class JarClassesExposer
         {
             identification.addGroupId( packagename );
         }
-    }
-
-    public void setAnalyzer( JarClassesAnalysis analyzer )
-    {
-        this.analyzer = analyzer;
     }
 }

--- a/src/main/java/org/apache/maven/shared/jar/identification/exposers/ManifestExposer.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/exposers/ManifestExposer.java
@@ -19,10 +19,12 @@ package org.apache.maven.shared.jar.identification.exposers;
  * under the License.
  */
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.maven.shared.jar.JarAnalyzer;
 import org.apache.maven.shared.jar.identification.JarIdentification;
 import org.apache.maven.shared.jar.identification.JarIdentificationExposer;
-import org.codehaus.plexus.component.annotations.Component;
 
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
@@ -30,10 +32,12 @@ import java.util.jar.Manifest;
 /**
  * Exposer that examines a JAR's manifest to derive Maven metadata.
  */
-@Component( role = JarIdentificationExposer.class, hint = "manifest" )
+@Singleton
+@Named( "manifest" )
 public class ManifestExposer
     implements JarIdentificationExposer
 {
+    @Override
     public void expose( JarIdentification identification, JarAnalyzer jarAnalyzer )
     {
         Manifest manifest = jarAnalyzer.getJarData().getManifest();

--- a/src/main/java/org/apache/maven/shared/jar/identification/exposers/RepositorySearchExposer.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/exposers/RepositorySearchExposer.java
@@ -19,31 +19,29 @@ package org.apache.maven.shared.jar.identification.exposers;
  * under the License.
  */
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.shared.jar.JarAnalyzer;
 import org.apache.maven.shared.jar.identification.JarIdentification;
 import org.apache.maven.shared.jar.identification.JarIdentificationExposer;
 import org.apache.maven.shared.jar.identification.hash.JarHashAnalyzer;
 import org.apache.maven.shared.jar.identification.repository.RepositoryHashSearch;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Exposer that examines a Maven repository for identical files to the JAR being analyzed. It will look for both
  * identical files, and files with identical classes.
- * <p/>
- * Note: if not using Plexus, you must call the following methods to be able to expose any data from the class:
- * {@link #setBytecodeHashAnalyzer(org.apache.maven.shared.jar.identification.hash.JarHashAnalyzer)},
- * {@link #setFileHashAnalyzer(org.apache.maven.shared.jar.identification.hash.JarHashAnalyzer)},
- * {@link #setRepositoryHashSearch(org.apache.maven.shared.jar.identification.repository.RepositoryHashSearch)}
  */
-@Component( role = JarIdentificationExposer.class, hint = "repositorySearch" )
+@Singleton
+@Named( "repositorySearch" )
 public class RepositorySearchExposer
-    extends AbstractLogEnabled
     implements JarIdentificationExposer
 {
     /**
@@ -51,21 +49,29 @@ public class RepositorySearchExposer
      *
      * @todo this currently only provides for the 'empty' repository search, which isn't very useful
      */
-    @Requirement
-    private RepositoryHashSearch repositoryHashSearch;
+    private final RepositoryHashSearch repositoryHashSearch;
 
     /**
      * The hash analyzer for the entire file.
      */
-    @Requirement( hint = "file" )
-    private JarHashAnalyzer fileHashAnalyzer;
+    private final JarHashAnalyzer fileHashAnalyzer;
 
     /**
      * The hash analyzer for the file's bytecode.
      */
-    @Requirement( hint = "bytecode" )
-    private JarHashAnalyzer bytecodeHashAnalyzer;
+    private final JarHashAnalyzer bytecodeHashAnalyzer;
 
+    @Inject
+    public RepositorySearchExposer( RepositoryHashSearch repositoryHashSearch,
+                                    @Named( "file" ) JarHashAnalyzer fileHashAnalyzer,
+                                    @Named( "bytecode" ) JarHashAnalyzer bytecodeHashAnalyzer )
+    {
+        this.repositoryHashSearch = requireNonNull( repositoryHashSearch );
+        this.fileHashAnalyzer = requireNonNull( fileHashAnalyzer );
+        this.bytecodeHashAnalyzer = requireNonNull( bytecodeHashAnalyzer );
+    }
+
+    @Override
     public void expose( JarIdentification identification, JarAnalyzer jarAnalyzer )
     {
         List<Artifact> repohits = new ArrayList<>();
@@ -89,20 +95,5 @@ public class RepositorySearchExposer
             identification.addAndSetArtifactId( artifact.getArtifactId() );
             identification.addAndSetVersion( artifact.getVersion() );
         }
-    }
-
-    public void setRepositoryHashSearch( RepositoryHashSearch repo )
-    {
-        this.repositoryHashSearch = repo;
-    }
-
-    public void setFileHashAnalyzer( JarHashAnalyzer fileHashAnalyzer )
-    {
-        this.fileHashAnalyzer = fileHashAnalyzer;
-    }
-
-    public void setBytecodeHashAnalyzer( JarHashAnalyzer bytecodeHashAnalyzer )
-    {
-        this.bytecodeHashAnalyzer = bytecodeHashAnalyzer;
     }
 }

--- a/src/main/java/org/apache/maven/shared/jar/identification/exposers/StaticMainOutputExposer.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/exposers/StaticMainOutputExposer.java
@@ -19,10 +19,12 @@ package org.apache.maven.shared.jar.identification.exposers;
  * under the License.
  */
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.maven.shared.jar.JarAnalyzer;
 import org.apache.maven.shared.jar.identification.JarIdentification;
 import org.apache.maven.shared.jar.identification.JarIdentificationExposer;
-import org.codehaus.plexus.component.annotations.Component;
 
 import java.util.Collections;
 import java.util.List;
@@ -33,10 +35,12 @@ import java.util.List;
  *
  * @todo not currently implemented
  */
-@Component( role = JarIdentificationExposer.class, hint = "staticMainOutput" )
+@Singleton
+@Named( "staticMainOutput" )
 public class StaticMainOutputExposer
     implements JarIdentificationExposer
 {
+    @Override
     public void expose( JarIdentification identification, JarAnalyzer jarAnalyzer )
     {
         List<String> staticMains = findStaticMainVersions();

--- a/src/main/java/org/apache/maven/shared/jar/identification/exposers/TextFileExposer.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/exposers/TextFileExposer.java
@@ -19,12 +19,15 @@ package org.apache.maven.shared.jar.identification.exposers;
  * under the License.
  */
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.maven.shared.jar.JarAnalyzer;
 import org.apache.maven.shared.jar.identification.JarIdentification;
 import org.apache.maven.shared.jar.identification.JarIdentificationExposer;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
-import org.apache.maven.shared.utils.StringUtils;
+import org.codehaus.plexus.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -39,11 +42,14 @@ import java.util.jar.JarEntry;
  * Exposer that examines a a JAR for files that contain the text <code>version</code> (case-insensitive) and
  * adds the contents as potential version(s).
  */
-@Component( role = JarIdentificationExposer.class, hint = "textFile" )
+@Singleton
+@Named( "textFile" )
 public class TextFileExposer
-    extends AbstractLogEnabled
     implements JarIdentificationExposer
 {
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Override
     public void expose( JarIdentification identification, JarAnalyzer jarAnalyzer )
     {
         List<String> textFiles = findTextFileVersions( jarAnalyzer );
@@ -63,7 +69,7 @@ public class TextFileExposer
             // skip this entry if it's a class file.
             if ( !entry.getName().endsWith( ".class" ) ) //$NON-NLS-1$
             {
-                getLogger().debug( "Version Hit: " + entry.getName() );
+                logger.debug( "Version Hit: " + entry.getName() );
                 try ( InputStream is = jarAnalyzer.getEntryInputStream( entry ) )
                 {
                     BufferedReader br = new BufferedReader( new InputStreamReader( is ) );
@@ -72,7 +78,7 @@ public class TextFileExposer
                     // TODO: check for key=value pair.
                     // TODO: maybe even for groupId entries.
 
-                    getLogger().debug( line );
+                    logger.debug( line );
                     if ( StringUtils.isNotEmpty( line ) )
                     {
                         textVersions.add( line );
@@ -80,7 +86,7 @@ public class TextFileExposer
                 }
                 catch ( IOException e )
                 {
-                    getLogger().warn( "Unable to read line from " + entry.getName(), e );
+                    logger.warn( "Unable to read line from " + entry.getName(), e );
                 }
             }
         }

--- a/src/main/java/org/apache/maven/shared/jar/identification/exposers/TimestampExposer.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/exposers/TimestampExposer.java
@@ -19,13 +19,15 @@ package org.apache.maven.shared.jar.identification.exposers;
  * under the License.
  */
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.commons.collections4.Bag;
 import org.apache.commons.collections4.bag.HashBag;
 import org.apache.maven.shared.jar.JarAnalyzer;
 import org.apache.maven.shared.jar.identification.JarIdentification;
 import org.apache.maven.shared.jar.identification.JarIdentificationExposer;
-import org.apache.maven.shared.utils.StringUtils;
-import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.util.StringUtils;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -36,10 +38,12 @@ import java.util.jar.JarEntry;
 /**
  * Exposer that examines a a JAR and uses the most recent timestamp as a potential version.
  */
-@Component( role = JarIdentificationExposer.class, hint = "timestamp" )
+@Singleton
+@Named( "timestamp" )
 public class TimestampExposer
     implements JarIdentificationExposer
 {
+    @Override
     public void expose( JarIdentification identification, JarAnalyzer jarAnalyzer )
     {
         List<JarEntry> entries = jarAnalyzer.getEntries();

--- a/src/main/java/org/apache/maven/shared/jar/identification/hash/JarBytecodeHashAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/hash/JarBytecodeHashAnalyzer.java
@@ -19,36 +19,45 @@ package org.apache.maven.shared.jar.identification.hash;
  * under the License.
  */
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.maven.shared.jar.JarAnalyzer;
 import org.apache.maven.shared.jar.JarData;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.digest.DigesterException;
 import org.codehaus.plexus.digest.StreamingDigester;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.jar.JarEntry;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Analyzer that calculates the hash code for the entire file. Can be used to detect an exact copy of the file's class
  * data. Useful to see thru a recompile, recompression, or timestamp change.
- * <p/>
- * If you are not using Plexus, you must call {@link #setDigester(org.codehaus.plexus.digest.StreamingDigester)} before
- * use
  */
-@Component( role = JarHashAnalyzer.class, hint = "bytecode" )
+@Singleton
+@Named( "bytecode" )
 public class JarBytecodeHashAnalyzer
-    extends AbstractLogEnabled
     implements JarHashAnalyzer
 {
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
     /**
      * The streaming digester to use for computing the hash. Under Plexus, the default is SHA-1.
      */
-    @Requirement( hint = "sha1" )
-    private StreamingDigester digester;
+    private final StreamingDigester digester;
+
+    @Inject
+    public JarBytecodeHashAnalyzer( @Named( "sha1" ) StreamingDigester digester )
+    {
+        this.digester = requireNonNull( digester );
+    }
 
     public String computeHash( JarAnalyzer jarAnalyzer )
     {
@@ -74,14 +83,9 @@ public class JarBytecodeHashAnalyzer
             }
             catch ( DigesterException | IOException e )
             {
-                getLogger().warn( "Unable to calculate the hashcode.", e );
+                logger.warn( "Unable to calculate the hashcode.", e );
             }
         }
         return result;
-    }
-
-    public void setDigester( StreamingDigester digester )
-    {
-        this.digester = digester;
     }
 }

--- a/src/main/java/org/apache/maven/shared/jar/identification/hash/JarBytecodeHashAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/hash/JarBytecodeHashAnalyzer.java
@@ -19,14 +19,12 @@ package org.apache.maven.shared.jar.identification.hash;
  * under the License.
  */
 
-import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.maven.shared.jar.JarAnalyzer;
 import org.apache.maven.shared.jar.JarData;
-import org.codehaus.plexus.digest.DigesterException;
-import org.codehaus.plexus.digest.StreamingDigester;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,8 +32,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.jar.JarEntry;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * Analyzer that calculates the hash code for the entire file. Can be used to detect an exact copy of the file's class
@@ -48,17 +44,6 @@ public class JarBytecodeHashAnalyzer
 {
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
-    /**
-     * The streaming digester to use for computing the hash. Under Plexus, the default is SHA-1.
-     */
-    private final StreamingDigester digester;
-
-    @Inject
-    public JarBytecodeHashAnalyzer( @Named( "sha1" ) StreamingDigester digester )
-    {
-        this.digester = requireNonNull( digester );
-    }
-
     public String computeHash( JarAnalyzer jarAnalyzer )
     {
         JarData jarData = jarAnalyzer.getJarData();
@@ -70,18 +55,16 @@ public class JarBytecodeHashAnalyzer
 
             try
             {
-                digester.reset();
                 for ( JarEntry entry : entries )
                 {
                     try ( InputStream is = jarAnalyzer.getEntryInputStream( entry ) )
                     {
-                        digester.update( is );
+                        result = DigestUtils.sha1Hex( is );
                     }
                 }
-                result = digester.calc();
                 jarData.setBytecodeHash( result );
             }
-            catch ( DigesterException | IOException e )
+            catch ( IOException e )
             {
                 logger.warn( "Unable to calculate the hashcode.", e );
             }

--- a/src/main/java/org/apache/maven/shared/jar/identification/hash/JarFileHashAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/hash/JarFileHashAnalyzer.java
@@ -19,29 +19,39 @@ package org.apache.maven.shared.jar.identification.hash;
  * under the License.
  */
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.maven.shared.jar.JarAnalyzer;
 import org.apache.maven.shared.jar.JarData;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.digest.Digester;
 import org.codehaus.plexus.digest.DigesterException;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Analyzer that calculates the hash code for the entire file. Can be used to detect an exact copy of the file.
- * <p/>
- * If you are not using Plexus, you must call {@link #setDigester(org.codehaus.plexus.digest.Digester)} before use
  */
-@Component( role = JarHashAnalyzer.class, hint = "file" )
+@Singleton
+@Named( "file" )
 public class JarFileHashAnalyzer
-    extends AbstractLogEnabled
     implements JarHashAnalyzer
 {
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
     /**
      * The digester to use for computing the hash. Under Plexus, the default is SHA-1.
      */
-    @Requirement( hint = "sha1" )
-    private Digester digester;
+    private final Digester digester;
+
+    @Inject
+    public JarFileHashAnalyzer( @Named( "sha1" ) Digester digester )
+    {
+        this.digester = requireNonNull( digester );
+    }
 
     public String computeHash( JarAnalyzer jarAnalyzer )
     {
@@ -57,14 +67,9 @@ public class JarFileHashAnalyzer
             }
             catch ( DigesterException e )
             {
-                getLogger().warn( "Unable to calculate the hashcode.", e );
+                logger.warn( "Unable to calculate the hashcode.", e );
             }
         }
         return result;
-    }
-
-    public void setDigester( Digester digester )
-    {
-        this.digester = digester;
     }
 }

--- a/src/main/java/org/apache/maven/shared/jar/identification/repository/EmptyRepositoryHashSearch.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/repository/EmptyRepositoryHashSearch.java
@@ -19,11 +19,13 @@ package org.apache.maven.shared.jar.identification.repository;
  * under the License.
  */
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import java.util.Collections;
 import java.util.List;
 
 import org.apache.maven.artifact.Artifact;
-import org.codehaus.plexus.component.annotations.Component;
 
 /**
  * Empty repository hash search.  Always returns an empty list.
@@ -32,7 +34,8 @@ import org.codehaus.plexus.component.annotations.Component;
  * an implementation of a {@link org.apache.maven.shared.jar.identification.repository.RepositoryHashSearch} against a
  * real repository.
  */
-@Component( role = RepositoryHashSearch.class, hint = "empty" )
+@Singleton
+@Named( "empty" )
 public class EmptyRepositoryHashSearch
     implements RepositoryHashSearch
 {

--- a/src/test/java/org/apache/maven/shared/jar/AbstractJarAnalyzerTestCase.java
+++ b/src/test/java/org/apache/maven/shared/jar/AbstractJarAnalyzerTestCase.java
@@ -20,6 +20,8 @@ package org.apache.maven.shared.jar;
  */
 
 import junit.framework.AssertionFailedError;
+import org.codehaus.plexus.ContainerConfiguration;
+import org.codehaus.plexus.PlexusConstants;
 import org.codehaus.plexus.PlexusTestCase;
 
 import java.io.File;
@@ -39,6 +41,12 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public abstract class AbstractJarAnalyzerTestCase
     extends PlexusTestCase
 {
+    @Override
+    protected void customizeContainerConfiguration( ContainerConfiguration configuration )
+    {
+        configuration.setAutoWiring( true ).setClassPathScanning( PlexusConstants.SCANNING_CACHE );
+    }
+
     protected File getSampleJar( String filename )
         throws UnsupportedEncodingException
     {


### PR DESCRIPTION
Changes:
* update to parent POM 36
* drop Plexus and Plexus APIs, convert to JSR330
* Update to Java8
* Update dependencies blocked by Java8 (bcel, commons-collections)

---

https://issues.apache.org/jira/browse/MSHARED-1098