### PR TITLE
[MNG-6829] Replace StringUtils#isEmpty(String) and #isNotEmpty(String)

### DIFF
--- a/src/main/java/org/apache/maven/shared/jar/JarData.java
+++ b/src/main/java/org/apache/maven/shared/jar/JarData.java
@@ -27,7 +27,6 @@ import java.util.jar.Manifest;
 
 import org.apache.maven.shared.jar.classes.JarClasses;
 import org.apache.maven.shared.jar.identification.JarIdentification;
-import org.codehaus.plexus.util.StringUtils;
 
 /**
  * Class that contains details of a single JAR file and it's entries.
@@ -90,7 +89,7 @@ public final class JarData {
         boolean aSealed = false;
         if (this.manifest != null) {
             String sval = this.manifest.getMainAttributes().getValue(Attributes.Name.SEALED);
-            if (StringUtils.isNotEmpty(sval)) {
+            if (sval != null && !sval.isEmpty()) {
                 aSealed = "true".equalsIgnoreCase(sval.trim());
             }
         }

--- a/src/main/java/org/apache/maven/shared/jar/identification/JarIdentificationAnalysis.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/JarIdentificationAnalysis.java
@@ -105,7 +105,7 @@ public class JarIdentificationAnalysis {
 
         int size = Integer.MAX_VALUE;
         for (String val : list) {
-            if (StringUtils.isNotEmpty(val)) {
+            if (val != null && !val.isEmpty()) {
                 if (val.length() < size) {
                     smallest = val;
                     size = val.length();
@@ -120,7 +120,7 @@ public class JarIdentificationAnalysis {
         String largest = null;
         int size = Integer.MIN_VALUE;
         for (String val : list) {
-            if (StringUtils.isNotEmpty(val)) {
+            if (val != null && !val.isEmpty()) {
                 if (val.length() > size) {
                     largest = val;
                     size = val.length();

--- a/src/main/java/org/apache/maven/shared/jar/identification/exposers/TextFileExposer.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/exposers/TextFileExposer.java
@@ -32,7 +32,6 @@ import java.util.jar.JarEntry;
 import org.apache.maven.shared.jar.JarAnalyzer;
 import org.apache.maven.shared.jar.identification.JarIdentification;
 import org.apache.maven.shared.jar.identification.JarIdentificationExposer;
-import org.codehaus.plexus.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,7 +69,7 @@ public class TextFileExposer implements JarIdentificationExposer {
                     // TODO: maybe even for groupId entries.
 
                     logger.debug(line);
-                    if (StringUtils.isNotEmpty(line)) {
+                    if (line != null && !line.isEmpty()) {
                         textVersions.add(line);
                     }
                 } catch (IOException e) {

--- a/src/main/java/org/apache/maven/shared/jar/identification/exposers/TimestampExposer.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/exposers/TimestampExposer.java
@@ -32,7 +32,6 @@ import org.apache.commons.collections4.bag.HashBag;
 import org.apache.maven.shared.jar.JarAnalyzer;
 import org.apache.maven.shared.jar.identification.JarIdentification;
 import org.apache.maven.shared.jar.identification.JarIdentificationExposer;
-import org.codehaus.plexus.util.StringUtils;
 
 /**
  * Exposer that examines a a JAR and uses the most recent timestamp as a potential version.
@@ -61,7 +60,7 @@ public class TimestampExposer implements JarIdentificationExposer {
             }
         }
 
-        if (StringUtils.isNotEmpty(ts)) {
+        if (ts != null && !ts.isEmpty()) {
             identification.addVersion(ts);
         }
     }


### PR DESCRIPTION
Continuation of https://issues.apache.org/jira/browse/MNG-6829

Review requested of @elharo

Use this link to re-run the recipe: https://public.moderne.io/recipes/org.openrewrite.java.migrate.apache.commons.lang.IsNotEmptyToJdk?organizationId=QXBhY2hlIE1hdmVu