### PR TITLE
Accumulate SHA-1 digest across all class entries for the bytecode hash (#133)

### DIFF
--- a/src/main/java/org/apache/maven/shared/jar/identification/hash/JarBytecodeHashAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/hash/JarBytecodeHashAnalyzer.java
@@ -23,10 +23,12 @@ import javax.inject.Singleton;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.jar.JarEntry;
 
-import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.maven.shared.jar.JarAnalyzer;
 import org.apache.maven.shared.jar.JarData;
 import org.slf4j.Logger;
@@ -49,13 +51,19 @@ public class JarBytecodeHashAnalyzer implements JarHashAnalyzer {
             List<JarEntry> entries = jarAnalyzer.getClassEntries();
 
             try {
+                MessageDigest sha1 = MessageDigest.getInstance("SHA-1");
+                byte[] buffer = new byte[8192];
                 for (JarEntry entry : entries) {
                     try (InputStream is = jarAnalyzer.getEntryInputStream(entry)) {
-                        result = DigestUtils.sha1Hex(is);
+                        int read;
+                        while ((read = is.read(buffer)) != -1) {
+                            sha1.update(buffer, 0, read);
+                        }
                     }
                 }
+                result = Hex.encodeHexString(sha1.digest());
                 jarData.setBytecodeHash(result);
-            } catch (IOException e) {
+            } catch (IOException | NoSuchAlgorithmException e) {
                 logger.warn("Unable to calculate the hashcode.", e);
             }
         }

--- a/src/main/java/org/apache/maven/shared/jar/identification/hash/JarBytecodeHashAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/hash/JarBytecodeHashAnalyzer.java
@@ -54,7 +54,7 @@ public class JarBytecodeHashAnalyzer implements JarHashAnalyzer {
                 MessageDigest sha1 = DigestUtils.getSha1Digest();
                 for (JarEntry entry : entries) {
                     try (InputStream is = jarAnalyzer.getEntryInputStream(entry)) {
-                        DigestUtils.updateDigest(is);
+                        DigestUtils.updateDigest(sha1, is);
                     }
                 }
                 result = Hex.encodeHexString(sha1.digest());

--- a/src/main/java/org/apache/maven/shared/jar/identification/hash/JarBytecodeHashAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/hash/JarBytecodeHashAnalyzer.java
@@ -51,7 +51,6 @@ public class JarBytecodeHashAnalyzer implements JarHashAnalyzer {
 
             try {
                 MessageDigest sha1 = DigestUtils.getSha1Digest();
-                byte[] buffer = new byte[8192];
                 for (JarEntry entry : entries) {
                     try (InputStream is = jarAnalyzer.getEntryInputStream(entry)) {
                         DigestUtils.updateDigest(is);

--- a/src/main/java/org/apache/maven/shared/jar/identification/hash/JarBytecodeHashAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/hash/JarBytecodeHashAnalyzer.java
@@ -24,7 +24,6 @@ import javax.inject.Singleton;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.jar.JarEntry;
 
@@ -60,7 +59,7 @@ public class JarBytecodeHashAnalyzer implements JarHashAnalyzer {
                 }
                 result = Hex.encodeHexString(sha1.digest());
                 jarData.setBytecodeHash(result);
-            } catch (IOException | NoSuchAlgorithmException e) {
+            } catch (IOException e) {
                 logger.warn("Unable to calculate the hashcode.", e);
             }
         }

--- a/src/main/java/org/apache/maven/shared/jar/identification/hash/JarBytecodeHashAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/hash/JarBytecodeHashAnalyzer.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Analyzer that calculates the hash code for the entire file. Can be used to detect an exact copy of the file's class
- * data. Useful to see thru a recompile, recompression, or timestamp change.
+ * data. Useful to see through a recompile, recompression, or timestamp change.
  */
 @Singleton
 @Named("bytecode")

--- a/src/main/java/org/apache/maven/shared/jar/identification/hash/JarBytecodeHashAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/hash/JarBytecodeHashAnalyzer.java
@@ -51,14 +51,11 @@ public class JarBytecodeHashAnalyzer implements JarHashAnalyzer {
             List<JarEntry> entries = jarAnalyzer.getClassEntries();
 
             try {
-                MessageDigest sha1 = MessageDigest.getInstance("SHA-1");
+                MessageDigest sha1 = DigestUtils.getSha1Digest();
                 byte[] buffer = new byte[8192];
                 for (JarEntry entry : entries) {
                     try (InputStream is = jarAnalyzer.getEntryInputStream(entry)) {
-                        int read;
-                        while ((read = is.read(buffer)) != -1) {
-                            sha1.update(buffer, 0, read);
-                        }
+                        DigestUtils.updateDigest(is);
                     }
                 }
                 result = Hex.encodeHexString(sha1.digest());

--- a/src/main/java/org/apache/maven/shared/jar/identification/hash/JarBytecodeHashAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/hash/JarBytecodeHashAnalyzer.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.jar.JarEntry;
 
 import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.maven.shared.jar.JarAnalyzer;
 import org.apache.maven.shared.jar.JarData;
 import org.slf4j.Logger;

--- a/src/test/java/org/apache/maven/shared/jar/identification/hash/JarBytecodeHashAnalyzerTest.java
+++ b/src/test/java/org/apache/maven/shared/jar/identification/hash/JarBytecodeHashAnalyzerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.shared.jar.identification.hash;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.maven.shared.jar.AbstractJarAnalyzerTestCase;
+import org.apache.maven.shared.jar.JarAnalyzer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Tests for the {@link JarBytecodeHashAnalyzer}.
+ */
+class JarBytecodeHashAnalyzerTest extends AbstractJarAnalyzerTestCase {
+
+    private final JarBytecodeHashAnalyzer analyzer = new JarBytecodeHashAnalyzer();
+
+    @Test
+    void computeHashCoversAllClassEntries() throws Exception {
+        JarAnalyzer jarAnalyzer = new JarAnalyzer(getSampleJar("codec.jar"));
+        try {
+            ByteArrayOutputStream allClasses = new ByteArrayOutputStream();
+            for (JarEntry entry : jarAnalyzer.getClassEntries()) {
+                try (InputStream is = jarAnalyzer.getEntryInputStream(entry)) {
+                    allClasses.write(readAll(is));
+                }
+            }
+            String expected = DigestUtils.sha1Hex(allClasses.toByteArray());
+
+            String actual = analyzer.computeHash(jarAnalyzer);
+
+            assertEquals(expected, actual, "bytecode hash must cover every class entry");
+        } finally {
+            jarAnalyzer.closeQuietly();
+        }
+    }
+
+    @Test
+    void distinctClassSetsProduceDistinctHashes() throws Exception {
+        JarAnalyzer jarA = new JarAnalyzer(createJar("org/foo/A.class", "org/zshared/Z.class"));
+        JarAnalyzer jarB = new JarAnalyzer(createJar("org/bar/B.class", "org/zshared/Z.class"));
+        try {
+            assertNotEquals(
+                    analyzer.computeHash(jarA),
+                    analyzer.computeHash(jarB),
+                    "jars sharing only the last-sorted class entry must not produce the same bytecode hash");
+        } finally {
+            jarA.closeQuietly();
+            jarB.closeQuietly();
+        }
+    }
+
+    private File createJar(String... entryNames) throws IOException {
+        File file = File.createTempFile("bytecode-hash-test", ".jar");
+        file.deleteOnExit();
+        try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(file))) {
+            for (String entryName : entryNames) {
+                jos.putNextEntry(new JarEntry(entryName));
+                jos.write(entryName.getBytes(StandardCharsets.UTF_8));
+                jos.closeEntry();
+            }
+        }
+        return file;
+    }
+
+    private static byte[] readAll(InputStream is) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        byte[] buffer = new byte[8192];
+        int read;
+        while ((read = is.read(buffer)) != -1) {
+            out.write(buffer, 0, read);
+        }
+        return out.toByteArray();
+    }
+}


### PR DESCRIPTION
Fixes #133

## Problem
`JarBytecodeHashAnalyzer.computeHash()` overwrote `result` on each loop iteration, so the computed bytecode hash only covered the **last** class entry in the JAR:

```java
for (JarEntry entry : entries) {
    try (InputStream is = jarAnalyzer.getEntryInputStream(entry)) {
        result = DigestUtils.sha1Hex(is); // overwrites previous result
    }
}
```

As a result, two JARs with completely different class sets could produce the same `bytecodeHash` whenever their last-sorted class entry was identical, contradicting the analyzer's contract of detecting an exact copy of the file's class data.

## Fix
The SHA-1 digest is now updated incrementally across every class entry (in the stable, name-sorted order produced by `JarAnalyzer`), and the final digest is hex-encoded once after the loop.

## Tests
Added `JarBytecodeHashAnalyzerTest` with two tests, both verified to **fail before the fix** and pass after:
- `computeHashCoversAllClassEntries`: the hash of `codec.jar` (14 classes) equals the SHA-1 of the concatenated class bytes.
- `distinctClassSetsProduceDistinctHashes`: two JARs sharing only the last-sorted class entry produce different hashes (they previously hashed identically).