### PR TITLE
Let ZipException bubble up from JarAnalyzer constructor (#144)

### DIFF
--- a/src/main/java/org/apache/maven/shared/jar/JarAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/jar/JarAnalyzer.java
@@ -31,7 +31,6 @@ import java.util.jar.Manifest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipException;
 
 /**
  * Open a JAR file to be analyzed. Note that once created, the {@link #closeQuietly()} method should be called to
@@ -97,13 +96,7 @@ public class JarAnalyzer {
      *             will be closed if this occurs.
      */
     public JarAnalyzer(File file) throws IOException {
-        try {
-            this.jarFile = new JarFile(file);
-        } catch (ZipException e) {
-            ZipException ioe = new ZipException("Failed to open file " + file + " : " + e.getMessage());
-            ioe.initCause(e);
-            throw ioe;
-        }
+        this.jarFile = new JarFile(file);
 
         // Obtain entries list.
         List<JarEntry> entries = Collections.list(jarFile.entries());


### PR DESCRIPTION
Fixes #144

Removed the redundant `catch (ZipException)` block in the `JarAnalyzer` constructor. It re-wrapped the exception with a new message and a misleadingly-named `ioe` variable, adding no information beyond the original exception.

The constructor already declares `throws IOException` (and `ZipException` is a subclass), so the original exception now propagates unchanged. Also removed the now-unused `java.util.zip.ZipException` import.

The existing `invalidJarFile` test (which asserts `ZipException` is thrown for an invalid JAR) still passes.