### PR TITLE
fix(classes): keep inner class references ($) from UTF-8 pool in ImportVisitor

### DIFF
--- a/src/main/java/org/apache/maven/shared/jar/classes/ImportVisitor.java
+++ b/src/main/java/org/apache/maven/shared/jar/classes/ImportVisitor.java
@@ -47,12 +47,12 @@ public class ImportVisitor extends EmptyVisitor {
      * Pattern to detect if the import is qualified and allows retrieval of the actual import name from the string via
      * the group 1.
      */
-    private static final Pattern QUALIFIED_IMPORT_PATTERN = Pattern.compile("L([a-zA-Z][a-zA-Z0-9\\.]+);");
+    private static final Pattern QUALIFIED_IMPORT_PATTERN = Pattern.compile("L([a-zA-Z][a-zA-Z0-9\\.$]+);");
 
     /**
      * Pattern that checks whether a string is valid UTF-8. Imports that are not are ignored.
      */
-    private static final Pattern VALID_UTF8_PATTERN = Pattern.compile("^[\\(\\)\\[A-Za-z0-9;/]+$");
+    private static final Pattern VALID_UTF8_PATTERN = Pattern.compile("^[\\(\\)\\[A-Za-z0-9;/;$]+$");
 
     /**
      * Create an Import visitor.

--- a/src/test/java/org/apache/maven/shared/jar/classes/ImportVisitorTest.java
+++ b/src/test/java/org/apache/maven/shared/jar/classes/ImportVisitorTest.java
@@ -18,7 +18,13 @@
  */
 package org.apache.maven.shared.jar.classes;
 
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+
 import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 import org.apache.bcel.classfile.ClassParser;
@@ -29,8 +35,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Import Visitor Test
@@ -119,5 +127,35 @@ class ImportVisitorTest extends AbstractJarAnalyzerTestCase {
         List<String> imports = importVisitor.getImports();
         assertNotNull(imports, "Import List");
         assertTrue(imports.size() >= 4);
+    }
+
+    @Test
+    void utf8StringPoolInnerClassReferenceIsKept() throws Exception {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        assumeTrue(compiler != null, "requires a JDK with javac");
+
+        Path source = Files.createTempDirectory("importvisitor-src").resolve("InnerRefHolder.java");
+        Files.write(
+                source,
+                ("package org.test.innertest;\n"
+                                + "public class InnerRefHolder {\n"
+                                + "    public static final String REF = \"org/test/innertest/Outer$Inner\";\n"
+                                + "}")
+                        .getBytes(StandardCharsets.UTF_8));
+
+        Path classesDir = Files.createTempDirectory("importvisitor-classes");
+        assertEquals(0, compiler.run(null, null, null, "-d", classesDir.toString(), source.toString()), "compilation");
+
+        JavaClass javaClass = new ClassParser(classesDir
+                        .resolve("org/test/innertest/InnerRefHolder.class")
+                        .toString())
+                .parse();
+        ImportVisitor importVisitor = new ImportVisitor(javaClass);
+        DescendingVisitor descVisitor = new DescendingVisitor(javaClass, importVisitor);
+        javaClass.accept(descVisitor);
+
+        assertTrue(
+                importVisitor.getImports().contains("org.test.innertest.Outer$Inner"),
+                "imports should keep inner class references from the UTF-8 pool");
     }
 }


### PR DESCRIPTION
Fixes apache/maven-shared-jar#140

The UTF-8 constant pool filter in `ImportVisitor` (`VALID_UTF8_PATTERN`) rejected strings containing `$`, so inner class references like `org/apache/tools/ant/XmlLogger$TimedElement` were silently dropped from the discovered imports. Additionally, `QUALIFIED_IMPORT_PATTERN` did not allow `$`, causing raw descriptor strings (e.g. `L...$Inner;`) to leak in unparsed.

Changes:
- allow `$` in `VALID_UTF8_PATTERN`
- allow `$` in the qualified-class portion of `QUALIFIED_IMPORT_PATTERN` so descriptors are still unwrapped correctly
- add a regression test that compiles a class holding an inner-class reference in its UTF-8 pool and asserts it is collected as an import

All 76 tests pass; checkstyle clean.