### PR TITLE
Fix #136: allow underscores in class names matched by CLASS_FILTER

### DIFF
--- a/src/main/java/org/apache/maven/shared/jar/JarAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/jar/JarAnalyzer.java
@@ -67,7 +67,7 @@ public class JarAnalyzer {
      *
      * @todo why are inner classes and other potentially valid classes omitted? (It flukes it by finding everything after $)
      */
-    private static final Pattern CLASS_FILTER = Pattern.compile("[A-Za-z0-9]*\\.class$");
+    private static final Pattern CLASS_FILTER = Pattern.compile("[A-Za-z0-9_]*\\.class$");
 
     /**
      * Pattern to filter JAR entries for Maven POM files.

--- a/src/main/java/org/apache/maven/shared/jar/JarAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/jar/JarAnalyzer.java
@@ -67,7 +67,7 @@ public class JarAnalyzer {
      *
      * @todo why are inner classes and other potentially valid classes omitted? (It flukes it by finding everything after $)
      */
-    private static final Pattern CLASS_FILTER = Pattern.compile("[A-Za-z0-9_]*\\.class$");
+    private static final Pattern CLASS_FILTER = Pattern.compile("[A-Za-z0-9]*\\.class$");
 
     /**
      * Pattern to filter JAR entries for Maven POM files.

--- a/src/test/java/org/apache/maven/shared/jar/JarAnalyzerTest.java
+++ b/src/test/java/org/apache/maven/shared/jar/JarAnalyzerTest.java
@@ -19,7 +19,12 @@
 package org.apache.maven.shared.jar;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.stream.Collectors;
 import java.util.zip.ZipException;
 
 import org.junit.jupiter.api.AfterEach;
@@ -95,5 +100,34 @@ class JarAnalyzerTest extends AbstractJarAnalyzerTestCase {
             jarAnalyzer.closeQuietly();
             jarAnalyzer.closeQuietly();
         });
+    }
+
+    @Test
+    void getClassEntriesFindsClassesWithUnderscores() throws Exception {
+        File jarFile = File.createTempFile("jar-analyzer-underscore", ".jar");
+        jarFile.deleteOnExit();
+
+        try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jarFile))) {
+            for (String entryName : new String[] {
+                "org/example/My_Helper.class",
+                "org/example/some_test.class",
+                "org/example/UPPER_CASE.class",
+                "org/example/MyHelper.class"
+            }) {
+                jos.putNextEntry(new JarEntry(entryName));
+                jos.write(new byte[] {1, 2, 3});
+                jos.closeEntry();
+            }
+        }
+
+        jarAnalyzer = new JarAnalyzer(jarFile);
+
+        List<String> classNames =
+                jarAnalyzer.getClassEntries().stream().map(JarEntry::getName).collect(Collectors.toList());
+
+        assertTrue(classNames.contains("org/example/My_Helper.class"), "Missing underscore class: " + classNames);
+        assertTrue(classNames.contains("org/example/some_test.class"), "Missing underscore class: " + classNames);
+        assertTrue(classNames.contains("org/example/UPPER_CASE.class"), "Missing underscore class: " + classNames);
+        assertTrue(classNames.contains("org/example/MyHelper.class"), "Missing regular class: " + classNames);
     }
 }


### PR DESCRIPTION
Closes #136

### Summary

Adds a regression test for #136. The issue reports that `CLASS_FILTER` in `JarAnalyzer` rejects underscores in Java class names (`My_Helper.class`, `some_test.class`, etc.).

Investigation showed the described behavior does not reproduce: `filterEntries` uses `Matcher.find()`, so the pattern `[A-Za-z0-9]*\\.class$` matches any entry ending in `.class` regardless of what precedes it (the character class only matches the trailing alphanumeric run). No source change is therefore required.

### Test

Adds `getClassEntriesFindsClassesWithUnderscores` in `JarAnalyzerTest`, which builds a JAR in memory containing classes with underscores in their names (`My_Helper`, `some_test`, `UPPER_CASE`) alongside a regular class, and asserts all of them are returned by `getClassEntries()`. This documents the expected behavior and guards against regressions.