### PR TITLE
Fix #135: avoid NPE in JarVersionedRuntimes.getJarClasses for missing version

### DIFF
--- a/src/main/java/org/apache/maven/shared/jar/classes/JarVersionedRuntimes.java
+++ b/src/main/java/org/apache/maven/shared/jar/classes/JarVersionedRuntimes.java
@@ -53,10 +53,11 @@ public class JarVersionedRuntimes {
     /**
      * Return the JarClasses associated to the release.
      * @param version the release version.
-     * @return the JarClasses.
+     * @return the JarClasses, or null if the version is not present.
      */
     public JarClasses getJarClasses(Integer version) {
-        return versionedRuntimeMap.get(version).getJarClasses();
+        JarVersionedRuntime versionedRuntime = versionedRuntimeMap.get(version);
+        return versionedRuntime != null ? versionedRuntime.getJarClasses() : null;
     }
 
     /**

--- a/src/test/java/org/apache/maven/shared/jar/classes/JarVersionedRuntimesTest.java
+++ b/src/test/java/org/apache/maven/shared/jar/classes/JarVersionedRuntimesTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.shared.jar.classes;
+
+import java.util.Collections;
+import java.util.TreeMap;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Tests for {@link JarVersionedRuntimes}.
+ */
+class JarVersionedRuntimesTest {
+
+    @Test
+    void getJarClassesForExistingVersion() {
+        JarClasses jarClasses = new JarClasses();
+        jarClasses.setJdkRevision("11");
+        JarVersionedRuntime versionedRuntime = new JarVersionedRuntime(Collections.emptyList(), jarClasses);
+        JarVersionedRuntimes runtimes =
+                new JarVersionedRuntimes(new TreeMap<>(Collections.singletonMap(11, versionedRuntime)));
+
+        assertEquals(jarClasses, runtimes.getJarClasses(11));
+    }
+
+    /**
+     * Exposes issue #135: {@link JarVersionedRuntimes#getJarClasses(Integer)} must not throw
+     * a NullPointerException when the requested version is not present in the map.
+     */
+    @Test
+    void getJarClassesForMissingVersionReturnsNull() {
+        JarVersionedRuntime versionedRuntime = new JarVersionedRuntime(Collections.emptyList(), new JarClasses());
+        JarVersionedRuntimes runtimes =
+                new JarVersionedRuntimes(new TreeMap<>(Collections.singletonMap(11, versionedRuntime)));
+
+        assertNull(runtimes.getJarClasses(9));
+    }
+}


### PR DESCRIPTION
Fixes #135

`JarVersionedRuntimes.getJarClasses(Integer version)` called `versionedRuntimeMap.get(version).getJarClasses()`, which throws a `NullPointerException` when the requested version is not a key in the map. This is inconsistent with `getJarVersionedRuntime()`, which safely returns `null` for missing keys.

This change guards against a missing key and returns `null`, matching the documented behaviour of the sibling accessor.

Added a unit test `JarVersionedRuntimesTest` that reproduces the NPE (fails before the fix, passes after):

- `getJarClassesForExistingVersion` verifies the existing key still returns the expected `JarClasses`
- `getJarClassesForMissingVersionReturnsNull` verifies a missing version returns `null` instead of throwing