### PR TITLE
Fix #141: read all lines of version text files

### DIFF
--- a/src/main/java/org/apache/maven/shared/jar/identification/exposers/TextFileExposer.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/exposers/TextFileExposer.java
@@ -64,13 +64,15 @@ public class TextFileExposer implements JarIdentificationExposer {
                 try (InputStream is = jarAnalyzer.getEntryInputStream(entry)) {
                     BufferedReader br = new BufferedReader(new InputStreamReader(is));
 
-                    String line = br.readLine();
                     // TODO: check for key=value pair.
                     // TODO: maybe even for groupId entries.
 
-                    logger.debug(line);
-                    if (line != null && !line.isEmpty()) {
-                        textVersions.add(line);
+                    String line;
+                    while ((line = br.readLine()) != null) {
+                        logger.debug(line);
+                        if (!line.isEmpty()) {
+                            textVersions.add(line);
+                        }
                     }
                 } catch (IOException e) {
                     logger.warn("Unable to read line from " + entry.getName(), e);

--- a/src/main/java/org/apache/maven/shared/jar/identification/exposers/TextFileExposer.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/exposers/TextFileExposer.java
@@ -36,7 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Exposer that examines a a JAR for files that contain the text <code>version</code> (case-insensitive) and
+ * Exposer that examines a JAR for files that contain the text <code>version</code> (case-insensitive) and
  * adds the contents as potential version(s).
  */
 @Singleton

--- a/src/test/java/org/apache/maven/shared/jar/identification/exposers/TextFileExposerTest.java
+++ b/src/test/java/org/apache/maven/shared/jar/identification/exposers/TextFileExposerTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.shared.jar.identification.exposers;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import org.apache.maven.shared.jar.JarAnalyzer;
+import org.apache.maven.shared.jar.identification.JarIdentification;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test Case for {@link TextFileExposer}.
+ */
+class TextFileExposerTest {
+
+    @Test
+    void readsAllLinesOfVersionFile() throws Exception {
+        File jar = createJarWithVersionFile("META-INF/VERSION", "1.2.3\nrelease\n");
+
+        JarIdentification identification = new JarIdentification();
+        TextFileExposer exposer = new TextFileExposer();
+        exposer.expose(identification, new JarAnalyzer(jar));
+
+        List<String> versions = identification.getPotentialVersions();
+        assertEquals(Arrays.asList("1.2.3", "release"), versions);
+    }
+
+    @Test
+    void readsAllLinesOfVersionPropertiesFile() throws Exception {
+        File jar = createJarWithVersionFile(
+                "META-INF/version.properties", "Implementation-Version=2.0.0\nBuild-Number=42\n");
+
+        JarIdentification identification = new JarIdentification();
+        TextFileExposer exposer = new TextFileExposer();
+        exposer.expose(identification, new JarAnalyzer(jar));
+
+        List<String> versions = identification.getPotentialVersions();
+        assertEquals(Arrays.asList("Implementation-Version=2.0.0", "Build-Number=42"), versions);
+    }
+
+    private File createJarWithVersionFile(String entryName, String content) throws IOException {
+        File file = File.createTempFile("text-file-exposer-test", ".jar");
+        file.deleteOnExit();
+        try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(file))) {
+            jos.putNextEntry(new JarEntry(entryName));
+            jos.write(content.getBytes(StandardCharsets.UTF_8));
+            jos.closeEntry();
+        }
+        return file;
+    }
+}


### PR DESCRIPTION
Fixes #141

## Problem

`TextFileExposer` only read the first line of a version text file:

```java
String line = br.readLine();
if (line != null && !line.isEmpty()) {
    textVersions.add(line);
}
```

Version files with multi-line content (e.g. `key=value` pairs, multi-line version headers) lose all data beyond line 1.

## Fix

Read all lines in a loop:

```java
String line;
while ((line = br.readLine()) != null) {
    if (!line.isEmpty()) {
        textVersions.add(line);
    }
}
```

## Test

Added `TextFileExposerTest` with two tests that build jars containing multi-line version files and assert all lines are exposed. Both fail on the old code (only first line returned) and pass with the fix.