### PR TITLE
Return the file hash that was just computed instead of null

### DIFF
--- a/src/main/java/org/apache/maven/shared/jar/identification/hash/JarFileHashAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/jar/identification/hash/JarFileHashAnalyzer.java
@@ -48,7 +48,8 @@ public class JarFileHashAnalyzer implements JarHashAnalyzer {
             try {
                 try (InputStream inputStream =
                         Files.newInputStream(jarData.getFile().toPath())) {
-                    jarData.setFileHash(DigestUtils.sha1Hex(inputStream));
+                    result = DigestUtils.sha1Hex(inputStream);
+                    jarData.setFileHash(result);
                 }
             } catch (IOException e) {
                 logger.warn("Unable to calculate the hashcode.", e);

--- a/src/test/java/org/apache/maven/shared/jar/identification/hash/JarFileHashAnalyzerTest.java
+++ b/src/test/java/org/apache/maven/shared/jar/identification/hash/JarFileHashAnalyzerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.shared.jar.identification.hash;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.maven.shared.jar.AbstractJarAnalyzerTestCase;
+import org.apache.maven.shared.jar.JarAnalyzer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class JarFileHashAnalyzerTest extends AbstractJarAnalyzerTestCase {
+
+    private final JarFileHashAnalyzer analyzer = new JarFileHashAnalyzer();
+
+    @Test
+    void computeHashReturnsTheHashOnFirstCall() throws Exception {
+        JarAnalyzer jarAnalyzer = new JarAnalyzer(getSampleJar("codec.jar"));
+        try {
+            String expected;
+            try (InputStream in =
+                    Files.newInputStream(jarAnalyzer.getJarData().getFile().toPath())) {
+                expected = DigestUtils.sha1Hex(in);
+            }
+
+            String actual = analyzer.computeHash(jarAnalyzer);
+
+            assertNotNull(actual, "first call must return the hash it just computed, not null");
+            assertEquals(expected, actual, "file hash must be the SHA-1 of the jar file");
+        } finally {
+            jarAnalyzer.closeQuietly();
+        }
+    }
+
+    @Test
+    void computeHashIsStableAcrossCalls() throws Exception {
+        JarAnalyzer jarAnalyzer = new JarAnalyzer(getSampleJar("codec.jar"));
+        try {
+            String first = analyzer.computeHash(jarAnalyzer);
+            // Second call is served from the JarData cache rather than recomputed.
+            String second = analyzer.computeHash(jarAnalyzer);
+
+            assertEquals(first, second, "cached call must agree with the computed one");
+        } finally {
+            jarAnalyzer.closeQuietly();
+        }
+    }
+
+    @Test
+    void computeHashPopulatesJarData() throws Exception {
+        JarAnalyzer jarAnalyzer = new JarAnalyzer(getSampleJar("codec.jar"));
+        try {
+            String returned = analyzer.computeHash(jarAnalyzer);
+
+            assertEquals(
+                    returned,
+                    jarAnalyzer.getJarData().getFileHash(),
+                    "returned hash and the value cached on JarData must agree");
+        } finally {
+            jarAnalyzer.closeQuietly();
+        }
+    }
+}


### PR DESCRIPTION
While looking at #150 I noticed a separate defect in the sibling analyzer.

## Problem

`JarFileHashAnalyzer.computeHash()` reads the cached hash into a local, and when that is `null` it computes the SHA-1 and stores it on `JarData` — but never assigns it back to the local:

```java
String result = jarData.getFileHash();
if (result == null) {
    try (InputStream inputStream = Files.newInputStream(jarData.getFile().toPath())) {
        jarData.setFileHash(DigestUtils.sha1Hex(inputStream));   // stored on JarData
    }
    ...
}
return result;   // still null
```

So the **first** call returns `null` even when the hash was calculated successfully. Only a later call — served from the `JarData` cache — returns the real value.

`JarBytecodeHashAnalyzer`, immediately beside it, does this correctly:

```java
result = Hex.encodeHexString(sha1.digest());
jarData.setBytecodeHash(result);
```

This is reachable: `RepositorySearchExposer` calls `fileHashAnalyzer.computeHash(jarAnalyzer)` to look up a jar in the repository, so the first lookup behaves as though the file could not be hashed at all.

## Fix

Assign the computed hash to `result` before caching it — one line, matching what the bytecode analyzer already does.

## Tests

The class had no test at all; `JarBytecodeHashAnalyzer` is the only one of the two that was covered, which is likely why this survived. Adds `JarFileHashAnalyzerTest` with three cases:

| test | before | after |
|---|---|---|
| `computeHashReturnsTheHashOnFirstCall` | FAIL — `expected: not <null>` | pass |
| `computeHashIsStableAcrossCalls` | FAIL — `expected: <null> but was: <d2c8151…>` | pass |
| `computeHashPopulatesJarData` | FAIL — `expected: <null> but was: <d2c8151…>` | pass |

The second failure shows the bug precisely: the first call returned `null` while the cached second call returned the real hash.

```
before fix:  Tests run: 3, Failures: 3
after fix:   Tests run: 3, Failures: 0
full suite:  Tests run: 81, Failures: 0, Errors: 0
```

## Note

This does not address #150 itself — the `IOException` swallowing there needs the deprecation and new throwing method you described, which is a wider API change. Happy to take that separately if useful; I wanted to keep this one narrow since it is an unambiguous bug with a one-line fix.